### PR TITLE
`with`, instead of `env` is recommended for actions-gh-pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ jobs:
       run: echo "Time ${{ steps.adocbuild.outputs.time }}"
     - name: Deploy docs to ghpages
       uses: peaceiris/actions-gh-pages@v3
-      env:
+      with:
         deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-        PUBLISH_BRANCH: gh-pages
-        PUBLISH_DIR: ./
+        publish_branch: gh-pages
+        publish_dir: ./
 ```


### PR DESCRIPTION
Hey. In looking at your example, I found that the latest version of actions-gh-pages recommends to use `with` instead of `env`. Using your example directly I ran into https://github.com/peaceiris/actions-gh-pages/issues/123 . 