### PR TITLE
Avoid deprecated Ubuntu 18.04 Actions runner image

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ on:
     - main
 jobs:
   adoc_build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: asciidoctor -D docs --backend=html5 -o index.html -a toc2 docs/index.adoc 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Reference: https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/